### PR TITLE
powerman/dockerize

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ mvnw.cmd clean package -Ddocker-maven-plugin.version=0.34-SNAPSHOT
 1. Redis version
 
    ```bash
-   docker run --rm abrarov/redis:6.0.9-1.0.2
+   docker run --rm abrarov/redis:6.0.9-1.0.3
    ```
 
    Expected output looks like:
@@ -53,7 +53,7 @@ mvnw.cmd clean package -Ddocker-maven-plugin.version=0.34-SNAPSHOT
 1. [Redis CLI](https://github.com/redis/redis#playing-with-redis)
 
    ```bash
-   container_id="$(docker run -d abrarov/redis:6.0.9-1.0.2 redis-server)" && \
+   container_id="$(docker run -d abrarov/redis:6.0.9-1.0.3 redis-server)" && \
    docker exec "${container_id}" redis-cli ping && \
    docker rm -fv "${container_id}" > /dev/null
    ```
@@ -67,7 +67,7 @@ mvnw.cmd clean package -Ddocker-maven-plugin.version=0.34-SNAPSHOT
 1. j2cli version
 
    ```bash
-   docker run --rm abrarov/j2cli:0.3.10-1.0.2
+   docker run --rm abrarov/j2cli:0.3.10-1.0.3
    ```
 
    Expected output is:
@@ -89,7 +89,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Test connection to Redis
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.2 redis-cli -h redis ping
+   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.3 redis-cli -h redis ping
    ```
 
    Expected output is:
@@ -101,7 +101,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Put some data into Redis
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.2 redis-cli -h redis set foo bar
+   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.3 redis-cli -h redis set foo bar
    ```
 
    Expected output is:
@@ -125,7 +125,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Test persistence of stored data
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.2 redis-cli -h redis get foo
+   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.3 redis-cli -h redis get foo
    ```
 
    Expected output is:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ x-helper-dockerize: &helper-dockerize '/helper/dockerize'
 services:
 
   helper:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis-helper:${PROJECT_VERSION:-1.0.2}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis-helper:${PROJECT_VERSION:-1.0.3}'
     read_only: true
     volumes:
       - *helper-dir
 
   init:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis-init:${PROJECT_VERSION:-1.0.2}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis-init:${PROJECT_VERSION:-1.0.3}'
     command: *helper-wrapper-script
     environment:
       INIT_COMMAND: '/run.sh'
@@ -35,7 +35,7 @@ services:
       - 'helper:ro'
 
   redis:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis:${REDIS_VERSION:-6.0.9}-${PROJECT_VERSION:-1.0.2}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis:${REDIS_VERSION:-6.0.9}-${PROJECT_VERSION:-1.0.3}'
     command:
       - *helper-dockerize
       - '-wait'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,7 @@ services:
       REDIS_LISTEN_BACKLOG: '128'
       REDIS_PROTECTED_MODE: 'no'
       REDIS_DATA_DIR: *redis-data-dir
-    read_only: true
     volumes:
-      - '/tmp'
       - *redis-conf-dir
     volumes_from:
       - 'helper:ro'

--- a/helper-image/pom.xml
+++ b/helper-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>helper-image</artifactId>
@@ -41,9 +41,9 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/jwilder/dockerize/releases/download/v${dockerize.version}/dockerize-linux-amd64-v${dockerize.version}.tar.gz</url>
-                            <unpack>true</unpack>
+                            <url>https://github.com/powerman/dockerize/releases/download/v${dockerize.version}/dockerize-linux-x86_64</url>
                             <outputDirectory>${project.build.directory}</outputDirectory>
+                            <outputFileName>dockerize</outputFileName>
                             <sha256>${dockerize.sha256}</sha256>
                         </configuration>
                     </execution>

--- a/j2cli-builder-image/pom.xml
+++ b/j2cli-builder-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>j2cli-builder-image</artifactId>

--- a/j2cli-dist/pom.xml
+++ b/j2cli-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>j2cli-dist</artifactId>

--- a/j2cli-image/pom.xml
+++ b/j2cli-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>j2cli-image</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>redis-builder-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
 
     <scm>
@@ -39,8 +39,8 @@
         <busybox.sha256>51fcb60efbdf3e579550e9ab893730df56b33d0cc928a2a6467bd846cdfef7d8</busybox.sha256>
         <httpecho.version>0.2.3</httpecho.version>
         <httpecho.sha256>e30b29b72ad5ec1f6dfc8dee0c2fcd162f47127f2251b99e47b9ae8af1d7b917</httpecho.sha256>
-        <dockerize.version>0.6.1</dockerize.version>
-        <dockerize.sha256>1fa29cd41a5854fd5423e242f3ea9737a50a8c3bcf852c9e62b9eb02c6ccd370</dockerize.sha256>
+        <dockerize.version>0.12.0</dockerize.version>
+        <dockerize.sha256>5c241e7ec35a205cd53250585282462636ebb894072a4b34283dc3d9b7c9be29</dockerize.sha256>
         <j2cli.version>0.3.10</j2cli.version>
         <j2cli.venv.dir>/venv</j2cli.venv.dir>
         <docker.image.registry>abrarov</docker.image.registry>

--- a/redis-builder-image/pom.xml
+++ b/redis-builder-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>redis-builder-image</artifactId>

--- a/redis-dist/pom.xml
+++ b/redis-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>redis-dist</artifactId>

--- a/redis-image/pom.xml
+++ b/redis-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>redis-image</artifactId>

--- a/redis-init-image/pom.xml
+++ b/redis-init-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>redis-init-image</artifactId>


### PR DESCRIPTION
* Migrated to powerman/dockerize which is a forward development fork of original dockerize (jwilder/dockerize).
* Fixed Docker Compose project - read-only rootfs for init container may break redis container.

