### PR TITLE
Docker Maven Plugin 0.35.0 & Redis 6.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 env:
   global:
     - DOCKER_COMPOSE_VERSION: '1.27.4'
-    - REDIS_VERSION: '6.0.9'
+    - REDIS_VERSION: '6.2.1'
     - REDIS_SHA256: '2819b6d9c56be1f25cd157b9cb6b7c2733edcb46f4f6bcb1b79cefe639a2853b'
     - J2CLI_VERSION: '0.3.10'
     - DOCKERHUB_USER: 'abrarov'

--- a/README.md
+++ b/README.md
@@ -16,24 +16,19 @@ Builder of Docker image with [Redis](https://github.com/redis/redis) using
 1. If remote Docker instance is used then `DOCKER_HOST` environment variable should point to that
    engine and include the schema, like `tcp://docker-host:2375` instead of `docker-host:2375`.
 1. The current directory is a directory where this repository is cloned.
-1. docker-maven-plugin 0.34-SNAPSHOT from
-   [copy_mojo](https://github.com/mabrarov/docker-maven-plugin/tree/copy_mojo) branch
-   of [mabrarov/docker-maven-plugin](https://github.com/mabrarov/docker-maven-plugin) GitHub project
-   is built and installed into the local Maven repository.
-   Refer to [docker-maven-plugin issue #752](https://github.com/fabric8io/docker-maven-plugin/issues/752) for details.
 
 ### Building Steps
 
 Building with [Maven Wrapper](https://github.com/takari/maven-wrapper):
 
 ```bash
-./mvnw clean package -Ddocker-maven-plugin.version=0.34-SNAPSHOT
+./mvnw clean package
 ```
 
 or on Windows:
 
 ```bash
-mvnw.cmd clean package -Ddocker-maven-plugin.version=0.34-SNAPSHOT
+mvnw.cmd clean package
 ```
 
 ## Testing
@@ -41,19 +36,19 @@ mvnw.cmd clean package -Ddocker-maven-plugin.version=0.34-SNAPSHOT
 1. Redis version
 
    ```bash
-   docker run --rm abrarov/redis:6.0.9-1.0.5
+   docker run --rm abrarov/redis:6.2.1-1.1.0
    ```
 
    Expected output looks like:
 
    ```text
-   Redis server v=6.0.9 sha=00000000:0 malloc=jemalloc-5.1.0 bits=64 build=e9b33d1e886db04a
+   Redis server v=6.2.1 sha=00000000:0 malloc=jemalloc-5.1.0 bits=64 build=a93dda0c16dc7a5c
    ```
 
 1. [Redis CLI](https://github.com/redis/redis#playing-with-redis)
 
    ```bash
-   container_id="$(docker run -d abrarov/redis:6.0.9-1.0.5 redis-server)" && \
+   container_id="$(docker run -d abrarov/redis:6.2.1-1.1.0 redis-server)" && \
    docker exec "${container_id}" redis-cli ping && \
    docker rm -fv "${container_id}" > /dev/null
    ```
@@ -67,13 +62,13 @@ mvnw.cmd clean package -Ddocker-maven-plugin.version=0.34-SNAPSHOT
 1. j2cli version
 
    ```bash
-   docker run --rm abrarov/j2cli:0.3.10-1.0.5
+   docker run --rm abrarov/j2cli:0.3.10-1.1.0
    ```
 
    Expected output is:
 
    ```text
-   j2cli 0.3.10, Jinja2 2.11.2
+   j2cli 0.3.10, Jinja2 2.11.3
    ```
 
 ## Docker Compose
@@ -89,7 +84,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Test connection to Redis
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.5 redis-cli -h redis ping
+   docker run --rm --network redis_default abrarov/redis:6.2.1-1.1.0 redis-cli -h redis ping
    ```
 
    Expected output is:
@@ -101,7 +96,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Put some data into Redis
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.5 redis-cli -h redis set foo bar
+   docker run --rm --network redis_default abrarov/redis:6.2.1-1.1.0 redis-cli -h redis set foo bar
    ```
 
    Expected output is:
@@ -125,7 +120,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Test persistence of stored data
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.0.9-1.0.5 redis-cli -h redis get foo
+   docker run --rm --network redis_default abrarov/redis:6.2.1-1.1.0 redis-cli -h redis get foo
    ```
 
    Expected output is:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ volumes:
 
 services:
   helper:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis-helper:${PROJECT_VERSION:-1.0.5}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis-helper:${PROJECT_VERSION:-1.1.0}'
     read_only: true
     volumes:
       - *helper-dir
 
   init:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis-init:${PROJECT_VERSION:-1.0.5}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis-init:${PROJECT_VERSION:-1.1.0}'
     command: *helper-wrapper-script
     environment:
       INIT_COMMAND: '/run.sh'
@@ -38,7 +38,7 @@ services:
       - 'helper:ro'
 
   redis:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis:${REDIS_VERSION:-6.0.9}-${PROJECT_VERSION:-1.0.5}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis:${REDIS_VERSION:-6.2.1}-${PROJECT_VERSION:-1.1.0}'
     command:
       - *helper-dockerize
       - '-wait'

--- a/helper-image/pom.xml
+++ b/helper-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>helper-image</artifactId>

--- a/j2cli-builder-image/pom.xml
+++ b/j2cli-builder-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>j2cli-builder-image</artifactId>

--- a/j2cli-dist/pom.xml
+++ b/j2cli-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>j2cli-dist</artifactId>

--- a/j2cli-image/pom.xml
+++ b/j2cli-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>j2cli-image</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>redis-builder-parent</artifactId>
-    <version>1.0.5</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <scm>
@@ -33,8 +33,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <docker.verbose>true</docker.verbose>
         <docker.cleanup>none</docker.cleanup>
-        <redis.version>6.0.9</redis.version>
-        <redis.sha256>2819b6d9c56be1f25cd157b9cb6b7c2733edcb46f4f6bcb1b79cefe639a2853b</redis.sha256>
+        <redis.version>6.2.1</redis.version>
+        <redis.sha256>40a9139fd84b1a3956a2b501aa74261dfa1834420f83e68dd0e40ad5bd5974da</redis.sha256>
         <busybox.version>1.31.0</busybox.version>
         <busybox.sha256>51fcb60efbdf3e579550e9ab893730df56b33d0cc928a2a6467bd846cdfef7d8</busybox.sha256>
         <httpecho.version>0.2.3</httpecho.version>
@@ -57,7 +57,7 @@
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <download-maven-plugin.version>1.6.0</download-maven-plugin.version>
-        <docker-maven-plugin.version>0.33.0</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.35.0</docker-maven-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/redis-builder-image/pom.xml
+++ b/redis-builder-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>redis-builder-image</artifactId>

--- a/redis-dist/pom.xml
+++ b/redis-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>redis-dist</artifactId>

--- a/redis-image/pom.xml
+++ b/redis-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>redis-image</artifactId>

--- a/redis-init-image/pom.xml
+++ b/redis-init-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>redis-init-image</artifactId>


### PR DESCRIPTION
Migrated to Docker Maven Plugin 0.35.0 which officially supports copy goal and to the latest version of Redis - 6.2.1.