### PR TITLE
Fixed container name conflict in case of multiple builds running in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ mvnw.cmd clean package
 1. Redis version
 
    ```bash
-   docker run --rm abrarov/redis:6.2.6-1.1.0
+   docker run --rm abrarov/redis:6.2.6-1.2.0
    ```
 
    Expected output looks like:
@@ -48,7 +48,7 @@ mvnw.cmd clean package
 1. [Redis CLI](https://github.com/redis/redis#playing-with-redis)
 
    ```bash
-   container_id="$(docker run -d abrarov/redis:6.2.6-1.1.0 redis-server)" && \
+   container_id="$(docker run -d abrarov/redis:6.2.6-1.2.0 redis-server)" && \
    docker exec "${container_id}" redis-cli ping && \
    docker rm -fv "${container_id}" > /dev/null
    ```
@@ -62,7 +62,7 @@ mvnw.cmd clean package
 1. j2cli version
 
    ```bash
-   docker run --rm abrarov/j2cli:0.3.10-1.1.0
+   docker run --rm abrarov/j2cli:0.3.10-1.2.0
    ```
 
    Expected output is:
@@ -84,7 +84,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Test connection to Redis
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.2.6-1.1.0 redis-cli -h redis ping
+   docker run --rm --network redis_default abrarov/redis:6.2.6-1.2.0 redis-cli -h redis ping
    ```
 
    Expected output is:
@@ -96,7 +96,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Put some data into Redis
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.2.6-1.1.0 redis-cli -h redis set foo bar
+   docker run --rm --network redis_default abrarov/redis:6.2.6-1.2.0 redis-cli -h redis set foo bar
    ```
 
    Expected output is:
@@ -120,7 +120,7 @@ Assuming the current directory is a directory where this repository is cloned.
 * Test persistence of stored data
 
    ```bash
-   docker run --rm --network redis_default abrarov/redis:6.2.6-1.1.0 redis-cli -h redis get foo
+   docker run --rm --network redis_default abrarov/redis:6.2.6-1.2.0 redis-cli -h redis get foo
    ```
 
    Expected output is:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ volumes:
 
 services:
   helper:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis-helper:${PROJECT_VERSION:-1.1.0}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis-helper:${PROJECT_VERSION:-1.2.0}'
     read_only: true
     volumes:
       - *helper-dir
 
   init:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis-init:${PROJECT_VERSION:-1.1.0}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis-init:${PROJECT_VERSION:-1.2.0}'
     command: *helper-wrapper-script
     environment:
       INIT_COMMAND: '/run.sh'
@@ -38,7 +38,7 @@ services:
       - 'helper:ro'
 
   redis:
-    image: '${IMAGE_REGISTRY:-abrarov}/redis:${REDIS_VERSION:-6.2.6}-${PROJECT_VERSION:-1.1.0}'
+    image: '${IMAGE_REGISTRY:-abrarov}/redis:${REDIS_VERSION:-6.2.6}-${PROJECT_VERSION:-1.2.0}'
     command:
       - *helper-dockerize
       - '-wait'

--- a/helper-image/pom.xml
+++ b/helper-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>helper-image</artifactId>

--- a/j2cli-builder-image/pom.xml
+++ b/j2cli-builder-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>j2cli-builder-image</artifactId>

--- a/j2cli-dist/pom.xml
+++ b/j2cli-dist/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <artifact.file>${project.build.directory}/${redis.builder.output.fileName}</artifact.file>
+        <docker.containerNamePattern>%e</docker.containerNamePattern>
     </properties>
 
     <dependencies>

--- a/j2cli-dist/pom.xml
+++ b/j2cli-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>j2cli-dist</artifactId>

--- a/j2cli-image/pom.xml
+++ b/j2cli-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>j2cli-image</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.fabric8.dmp.samples</groupId>
     <artifactId>redis-builder-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>pom</packaging>
 
     <scm>

--- a/redis-builder-image/pom.xml
+++ b/redis-builder-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>redis-builder-image</artifactId>

--- a/redis-dist/pom.xml
+++ b/redis-dist/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <artifact.file>${project.build.directory}/${redis.builder.output.fileName}</artifact.file>
+        <docker.containerNamePattern>%e</docker.containerNamePattern>
     </properties>
 
     <dependencies>

--- a/redis-dist/pom.xml
+++ b/redis-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>redis-dist</artifactId>

--- a/redis-image/pom.xml
+++ b/redis-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>redis-image</artifactId>

--- a/redis-init-image/pom.xml
+++ b/redis-init-image/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.fabric8.dmp.samples</groupId>
         <artifactId>redis-builder-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <artifactId>redis-init-image</artifactId>


### PR DESCRIPTION
Fixed container name conflict in case of multiple builds running in parallel by using auto-generated name of container, which is created to copy media from existing container image.